### PR TITLE
Fix: Switch JAX version to latest JAX release 0.8.0

### DIFF
--- a/.github/workflows/gpu-multihost-training-test.yaml
+++ b/.github/workflows/gpu-multihost-training-test.yaml
@@ -14,8 +14,7 @@ jobs:
       JOBSET_HEALTHY_TIMEOUT: 900
       ACCELERATOR: b200_16
       # Optional flags
-      CUSTOM_GIT_ORIGIN: https://github.com/judyzhaoxinwu/axlearn
-      CUSTOM_GIT_BRANCH: jax_nightly_py3.12
+      CUSTOM_GIT_BRANCH: jax_0.8.0_py3.12_v7x
       # CUSTOM_GIT_ORIGIN: https://github.com/apple/axlearn # Optionally point to another repo
       # CUSTOM_GIT_BRANCH: jax_0.6.2_py3.12 # Customize with a different branch
       # JOBSET_MAX_RESTARTS: 1 # Allow restarts in the JobSet. Default = 0 (no restarts)
@@ -29,7 +28,7 @@ jobs:
         id: launch_job
         run: |
           export GITHUB_OUTPUT=$GITHUB_OUTPUT
-          
+
           GH_RUN_ID=${{ github.run_id }} python3 /var/arc/launch_jobset.py
       - name: Upload the training result to GCS
         if: always()

--- a/.github/workflows/gpu-training-test.yaml
+++ b/.github/workflows/gpu-training-test.yaml
@@ -16,8 +16,7 @@ jobs:
         JOBSET_HEALTHY_TIMEOUT: 900
         ACCELERATOR: b200_8
         # Optional flags
-        CUSTOM_GIT_ORIGIN: https://github.com/judyzhaoxinwu/axlearn
-        CUSTOM_GIT_BRANCH: jax_nightly_py3.12
+        CUSTOM_GIT_BRANCH: jax_0.8.0_py3.12_v7x
         # CUSTOM_GIT_ORIGIN: https://github.com/apple/axlearn # Optionally point to another repo
         # CUSTOM_GIT_BRANCH: jax_0.6.2_py3.12 # Customize with a different branch
         # JOBSET_MAX_RESTARTS: 1 # Allow restarts in the JobSet. Default = 0 (no restarts)
@@ -28,7 +27,7 @@ jobs:
         id: launch_job
         run: |
           export GITHUB_OUTPUT=$GITHUB_OUTPUT
-    
+
           GH_RUN_ID=${{ github.run_id }} python3 /var/arc/launch_jobset.py
       - name: Upload the training result to GCS
         if: always()

--- a/.github/workflows/tpu-multislice-training-test.yaml
+++ b/.github/workflows/tpu-multislice-training-test.yaml
@@ -18,8 +18,7 @@ jobs:
         ACCELERATOR: v6e_4x4_2
         # Optional flags
         # CUSTOM_GIT_ORIGIN: https://github.com/apple/axlearn # Optionally point to another repo
-        CUSTOM_GIT_ORIGIN: https://github.com/judyzhaoxinwu/axlearn
-        CUSTOM_GIT_BRANCH: jax_nightly_py3.12
+        CUSTOM_GIT_BRANCH: jax_0.8.0_py3.12_v7x
         # CUSTOM_GIT_BRANCH: jax_0.6.2_py3.12 # Customize with a different branch
         # JOBSET_MAX_RESTARTS: 1 # Allow restarts in the JobSet. Default = 0 (no restarts)
     steps:

--- a/.github/workflows/tpu-single-slice-training-test.yaml
+++ b/.github/workflows/tpu-single-slice-training-test.yaml
@@ -19,8 +19,7 @@ jobs:
         ACCELERATOR: v6e_4x4_1
         # Optional flags
         # CUSTOM_GIT_ORIGIN: https://github.com/apple/axlearn # Optionally point to another repo
-        CUSTOM_GIT_ORIGIN: https://github.com/judyzhaoxinwu/axlearn
-        CUSTOM_GIT_BRANCH: jax_nightly_py3.12
+        CUSTOM_GIT_BRANCH: jax_0.8.0_py3.12_v7x
         # CUSTOM_GIT_BRANCH: jax_0.6.2_py3.12 # Customize with a different branch
         # JOBSET_MAX_RESTARTS: 1 # Allow restarts in the JobSet. Default = 0 (no restarts)
     steps:


### PR DESCRIPTION
# Description
Following the conversation in the chat space. I just change to point to the JAX branch that contains latest JAX 0.8.0.