### PR TITLE
Point to jax_py3.12_nightly in Axlearn repo

### DIFF
--- a/.github/workflows/cpu-unit-tests.yaml
+++ b/.github/workflows/cpu-unit-tests.yaml
@@ -15,7 +15,7 @@ jobs:
         RESUME_JOBSET: true
         # Optional flags
         # CUSTOM_GIT_ORIGIN: https://github.com/apple/axlearn # Optionally point to another repo
-        CUSTOM_GIT_BRANCH: jax_0.6.2_py3.12 # Customize with a different branch
+        CUSTOM_GIT_BRANCH: jax_py3.12_nightly
         # JOBSET_MAX_RESTARTS: 1 # Allow restarts in the JobSet. Default = 0 (no restarts)
     steps:
       - name: Install the Kubernetes Python SDK

--- a/.github/workflows/gpu-multihost-training-test.yaml
+++ b/.github/workflows/gpu-multihost-training-test.yaml
@@ -14,8 +14,7 @@ jobs:
       JOBSET_HEALTHY_TIMEOUT: 900
       ACCELERATOR: b200_16
       # Optional flags
-      CUSTOM_GIT_ORIGIN: https://github.com/judyzhaoxinwu/axlearn
-      CUSTOM_GIT_BRANCH: jax_nightly_py3.12
+      CUSTOM_GIT_BRANCH: jax_py3.12_nightly
       # CUSTOM_GIT_ORIGIN: https://github.com/apple/axlearn # Optionally point to another repo
       # CUSTOM_GIT_BRANCH: jax_0.6.2_py3.12 # Customize with a different branch
       # JOBSET_MAX_RESTARTS: 1 # Allow restarts in the JobSet. Default = 0 (no restarts)
@@ -29,7 +28,7 @@ jobs:
         id: launch_job
         run: |
           export GITHUB_OUTPUT=$GITHUB_OUTPUT
-          
+
           GH_RUN_ID=${{ github.run_id }} python3 /var/arc/launch_jobset.py
       - name: Upload the training result to GCS
         if: always()

--- a/.github/workflows/gpu-training-test.yaml
+++ b/.github/workflows/gpu-training-test.yaml
@@ -16,8 +16,7 @@ jobs:
         JOBSET_HEALTHY_TIMEOUT: 900
         ACCELERATOR: b200_8
         # Optional flags
-        CUSTOM_GIT_ORIGIN: https://github.com/judyzhaoxinwu/axlearn
-        CUSTOM_GIT_BRANCH: jax_nightly_py3.12
+        CUSTOM_GIT_BRANCH: jax_py3.12_nightly
         # CUSTOM_GIT_ORIGIN: https://github.com/apple/axlearn # Optionally point to another repo
         # CUSTOM_GIT_BRANCH: jax_0.6.2_py3.12 # Customize with a different branch
         # JOBSET_MAX_RESTARTS: 1 # Allow restarts in the JobSet. Default = 0 (no restarts)
@@ -28,7 +27,7 @@ jobs:
         id: launch_job
         run: |
           export GITHUB_OUTPUT=$GITHUB_OUTPUT
-    
+
           GH_RUN_ID=${{ github.run_id }} python3 /var/arc/launch_jobset.py
       - name: Upload the training result to GCS
         if: always()

--- a/.github/workflows/gpu-unit-tests.yaml
+++ b/.github/workflows/gpu-unit-tests.yaml
@@ -10,7 +10,7 @@ jobs:
         GCS_PREFIX: gs://axlearn-arc-testing/testing
         # Optional flags
         # CUSTOM_GIT_ORIGIN: https://github.com/apple/axlearn # Optionally point to another repo
-        CUSTOM_GIT_BRANCH: jax_0.6.2_py3.12 # Customize with a different branch
+        CUSTOM_GIT_BRANCH: jax_py3.12_nightly
     steps:
       - name: Persist the run id
         run: echo ${{ github.run_id }} > /var/arc/run_id

--- a/.github/workflows/tpu-multislice-training-test.yaml
+++ b/.github/workflows/tpu-multislice-training-test.yaml
@@ -18,8 +18,7 @@ jobs:
         ACCELERATOR: v6e_4x4_2
         # Optional flags
         # CUSTOM_GIT_ORIGIN: https://github.com/apple/axlearn # Optionally point to another repo
-        CUSTOM_GIT_ORIGIN: https://github.com/judyzhaoxinwu/axlearn
-        CUSTOM_GIT_BRANCH: jax_nightly_py3.12
+        CUSTOM_GIT_BRANCH: jax_py3.12_nightly
         # CUSTOM_GIT_BRANCH: jax_0.6.2_py3.12 # Customize with a different branch
         # JOBSET_MAX_RESTARTS: 1 # Allow restarts in the JobSet. Default = 0 (no restarts)
     steps:

--- a/.github/workflows/tpu-single-slice-training-test.yaml
+++ b/.github/workflows/tpu-single-slice-training-test.yaml
@@ -19,8 +19,7 @@ jobs:
         ACCELERATOR: v6e_4x4_1
         # Optional flags
         # CUSTOM_GIT_ORIGIN: https://github.com/apple/axlearn # Optionally point to another repo
-        CUSTOM_GIT_ORIGIN: https://github.com/judyzhaoxinwu/axlearn
-        CUSTOM_GIT_BRANCH: jax_nightly_py3.12
+        CUSTOM_GIT_BRANCH: jax_py3.12_nightly
         # CUSTOM_GIT_BRANCH: jax_0.6.2_py3.12 # Customize with a different branch
         # JOBSET_MAX_RESTARTS: 1 # Allow restarts in the JobSet. Default = 0 (no restarts)
     steps:

--- a/.github/workflows/tpu-unit-tests.yaml
+++ b/.github/workflows/tpu-unit-tests.yaml
@@ -10,7 +10,7 @@ jobs:
         GCS_PREFIX: gs://axlearn-arc-testing/testing
         # Optional flags
         # CUSTOM_GIT_ORIGIN: https://github.com/apple/axlearn # Optionally point to another repo
-        CUSTOM_GIT_BRANCH: jax_0.6.2_py3.12 # Customize with a different branch
+        CUSTOM_GIT_BRANCH: jax_py3.12_nightly
     steps:
       - name: Persist the run id
         run: echo ${{ github.run_id }} > /var/arc/run_id


### PR DESCRIPTION
# Description
Following the conversation in the chat space. Made following changes.
- Create a new branch on Borklet-Labs/axlearn repo called jax_py3.12_nightly
- Modify in axlearn-arc/jax_nightly_py3.12 branch to point to the previous created branch in axlearn (jax_py3.12_nightly).