### PR TITLE
Fix: Change duplicat name pw-single-slice-training-test 

### DIFF
--- a/.github/workflows/pw-single-slice-training-restore.yaml
+++ b/.github/workflows/pw-single-slice-training-restore.yaml
@@ -1,4 +1,4 @@
-name: pw-single-slice-training-test
+name: pw-single-slice-training-test-restore
 on:
   workflow_dispatch
 jobs:


### PR DESCRIPTION
### Description
Fix duplicate name `pw-single-slice-training-test` -->  `pw-single-slice-training-test-restore`