### PR TITLE
Cienet/replica resize

### DIFF
--- a/.github/workflows/pw-elastic-pause-resume-test.yaml
+++ b/.github/workflows/pw-elastic-pause-resume-test.yaml
@@ -21,7 +21,7 @@ jobs:
         RESTORE_MODE: True
         ENABLED_PAUSE_RESUME: True # For elastic training feature Pause && Resume
         CUSTOM_GIT_ORIGIN: https://github.com/Borklet-Labs/axlearn
-        CUSTOM_GIT_BRANCH: cienet/0_10_dev # Customize with a different branch
+        CUSTOM_GIT_BRANCH: cienet/elastic_training # Customize with a different branch
         # JOBSET_MAX_RESTARTS: 1 # Allow restarts in the JobSet. Default = 0 (no restarts)
         # SCHEDULE_TIMEOUT: 600 # Seconds to wait for job to be scheduled. Default = 900
         # FUJI_PATCH_FILE: /var/arc/fuji-main.patch # Path to a patch for axlearn/experiments/text/gpt/fuji.py

--- a/.github/workflows/pw-elastic-pause-resume-test.yaml
+++ b/.github/workflows/pw-elastic-pause-resume-test.yaml
@@ -19,6 +19,7 @@ jobs:
         MAX_STEPS: 300
         DELETE_MODE: node
         RESTORE_MODE: True
+        ENABLED_PAUSE_RESUME: True # For elastic training feature Pause && Resume
         CUSTOM_GIT_ORIGIN: https://github.com/Borklet-Labs/axlearn
         CUSTOM_GIT_BRANCH: cienet/0_10_dev # Customize with a different branch
         # JOBSET_MAX_RESTARTS: 1 # Allow restarts in the JobSet. Default = 0 (no restarts)

--- a/.github/workflows/pw-elastic-pause-resume-test.yaml
+++ b/.github/workflows/pw-elastic-pause-resume-test.yaml
@@ -1,17 +1,17 @@
-name: pw-ss-elastic-training-test
+name: pw-elastic-pause-resume-training-test
 on:
   workflow_dispatch
 jobs:
-  pw-tpu-single-slice-training-test-job:
+  pw-elastic-pause-resume-training-test-job:
     runs-on: jobset # Runs on CPU because this schedules a JobSet that's later routed to TPU
     container:
-      image: us-central2-docker.pkg.dev/tpu-prod-env-one-vm/camilo-tpu/pw-arc-jobset:latest
+      image: us-central2-docker.pkg.dev/tpu-prod-env-one-vm/camilo-tpu/pw-arc-jobset-replica:latest
       env:
         # Required environmental variables for a successful run
         ARC_JOBSET_NAME: arc-pw-ss-elastic-training
         ARC_JOBSET_JSON: /var/arc/arc-pw-single-elastic.json
         GCS_PREFIX: gs://axlearn-arc-testing/testing
-        JOBSET_DOCKER_IMAGE: us-central2-docker.pkg.dev/tpu-prod-env-one-vm/camilo-tpu/pw-arc-python:latest
+        JOBSET_DOCKER_IMAGE: us-central2-docker.pkg.dev/tpu-prod-env-one-vm/camilo-tpu/pw-arc-python-replica:latest
         JOBSET_HEALTHY_TIMEOUT: 2400
         ACCELERATOR: v6e_4x4_2
         # Optional flags
@@ -20,13 +20,14 @@ jobs:
         DELETE_MODE: node
         RESTORE_MODE: True
         CUSTOM_GIT_ORIGIN: https://github.com/Borklet-Labs/axlearn
-        CUSTOM_GIT_BRANCH: cienet/elastic_dev # Customize with a different branch
+        CUSTOM_GIT_BRANCH: cienet/0_10_dev # Customize with a different branch
         # JOBSET_MAX_RESTARTS: 1 # Allow restarts in the JobSet. Default = 0 (no restarts)
         # SCHEDULE_TIMEOUT: 600 # Seconds to wait for job to be scheduled. Default = 900
         # FUJI_PATCH_FILE: /var/arc/fuji-main.patch # Path to a patch for axlearn/experiments/text/gpt/fuji.py
         # ENABLE_JAX_DEV: # Set this to true to enable prereleases in uv and reference the Jax index
-        PW_PROXY_IMAGE: us-docker.pkg.dev/cloud-tpu-v2-images/pathways/proxy_server:20260206-jax_0.8.2
-        PW_SERVER_IMAGE: us-docker.pkg.dev/cloud-tpu-v2-images/pathways/server:20260206-jax_0.8.2
+        PW_PROXY_IMAGE: us-docker.pkg.dev/cloud-tpu-v2-images/pathways/proxy_server:20260501-jax_0.10.0
+        PW_SERVER_IMAGE: us-docker.pkg.dev/cloud-tpu-v2-images/pathways/server:20260501-jax_0.10.0
+        POST_SETUP_CMD: pip install importlib_resources && pip install jax==0.10.0 jaxlib==0.10.0 -i https://us-python.pkg.dev/ml-oss-artifacts-published/jax/simple/ --extra-index-url https://pypi.org/simple || echo setup_failed
     steps:
       - name: Install the Kubernetes Python SDK
         run: uv pip install kubernetes
@@ -60,7 +61,7 @@ jobs:
   interruption-jobset:
     runs-on: jobset
     container:
-      image: us-central2-docker.pkg.dev/tpu-prod-env-one-vm/camilo-tpu/pw-arc-jobset:latest
+      image: us-central2-docker.pkg.dev/tpu-prod-env-one-vm/camilo-tpu/pw-arc-jobset-replica:latest
       env:
         # Required environmental variables for a successful run
         JOBSET_HEALTHY_TIMEOUT: 2400

--- a/.github/workflows/pw-elastic-pause-resume-test.yaml
+++ b/.github/workflows/pw-elastic-pause-resume-test.yaml
@@ -5,13 +5,13 @@ jobs:
   pw-elastic-pause-resume-training-test-job:
     runs-on: jobset # Runs on CPU because this schedules a JobSet that's later routed to TPU
     container:
-      image: us-central2-docker.pkg.dev/tpu-prod-env-one-vm/camilo-tpu/pw-arc-jobset-replica:latest
+      image: us-central2-docker.pkg.dev/tpu-prod-env-one-vm/camilo-tpu/pw-arc-jobset:latest
       env:
         # Required environmental variables for a successful run
         ARC_JOBSET_NAME: arc-pw-ss-elastic-training
         ARC_JOBSET_JSON: /var/arc/arc-pw-single-elastic.json
         GCS_PREFIX: gs://axlearn-arc-testing/testing
-        JOBSET_DOCKER_IMAGE: us-central2-docker.pkg.dev/tpu-prod-env-one-vm/camilo-tpu/pw-arc-python-replica:latest
+        JOBSET_DOCKER_IMAGE: us-central2-docker.pkg.dev/tpu-prod-env-one-vm/camilo-tpu/pw-arc-python:latest
         JOBSET_HEALTHY_TIMEOUT: 2400
         ACCELERATOR: v6e_4x4_2
         # Optional flags
@@ -62,7 +62,7 @@ jobs:
   interruption-jobset:
     runs-on: jobset
     container:
-      image: us-central2-docker.pkg.dev/tpu-prod-env-one-vm/camilo-tpu/pw-arc-jobset-replica:latest
+      image: us-central2-docker.pkg.dev/tpu-prod-env-one-vm/camilo-tpu/pw-arc-jobset:latest
       env:
         # Required environmental variables for a successful run
         JOBSET_HEALTHY_TIMEOUT: 2400

--- a/.github/workflows/pw-elastic-replica-resize-test.yaml
+++ b/.github/workflows/pw-elastic-replica-resize-test.yaml
@@ -21,7 +21,7 @@ jobs:
         ENABLED_REPLICA_RESIZE: True # For elastic training feature Replica Resize
         # RESTORE_MODE: True
         CUSTOM_GIT_ORIGIN: https://github.com/Borklet-Labs/axlearn
-        CUSTOM_GIT_BRANCH: cienet/0_10_dev # Customize with a different branch
+        CUSTOM_GIT_BRANCH: cienet/elastic_training # Customize with a different branch
         PW_PROXY_IMAGE: us-docker.pkg.dev/cloud-tpu-v2-images/pathways/proxy_server:20260501-jax_0.10.0
         PW_SERVER_IMAGE: us-docker.pkg.dev/cloud-tpu-v2-images/pathways/server:20260501-jax_0.10.0
         POST_SETUP_CMD: pip install importlib_resources && pip install jax==0.10.0 jaxlib==0.10.0 -i https://us-python.pkg.dev/ml-oss-artifacts-published/jax/simple/ --extra-index-url https://pypi.org/simple || echo setup_failed

--- a/.github/workflows/pw-elastic-replica-resize-test.yaml
+++ b/.github/workflows/pw-elastic-replica-resize-test.yaml
@@ -18,6 +18,7 @@ jobs:
         STEPS_CHECKPOINT: 20
         MAX_STEPS: 100
         RESTORE_MODE: True
+        ENABLED_REPLICA_RESIZE: True # For elastic training feature Replica Resize
         # RESTORE_MODE: True
         CUSTOM_GIT_ORIGIN: https://github.com/Borklet-Labs/axlearn
         CUSTOM_GIT_BRANCH: cienet/0_10_dev # Customize with a different branch

--- a/.github/workflows/pw-elastic-replica-resize-test.yaml
+++ b/.github/workflows/pw-elastic-replica-resize-test.yaml
@@ -5,13 +5,13 @@ jobs:
   pw-elastic-replica-resize-training-test-job:
     runs-on: jobset # Runs on CPU because this schedules a JobSet that's later routed to TPU
     container:
-      image: us-central2-docker.pkg.dev/tpu-prod-env-one-vm/camilo-tpu/pw-arc-jobset-replica:latest
+      image: us-central2-docker.pkg.dev/tpu-prod-env-one-vm/camilo-tpu/pw-arc-jobset:latest
       env:
         # Required environmental variables for a successful run
         ARC_JOBSET_NAME: arc-pw-elastic-training
         ARC_JOBSET_JSON: /var/arc/arc-pw-elastic.json
         GCS_PREFIX: gs://axlearn-arc-testing/testing
-        JOBSET_DOCKER_IMAGE: us-central2-docker.pkg.dev/tpu-prod-env-one-vm/camilo-tpu/pw-arc-python-replica:latest
+        JOBSET_DOCKER_IMAGE: us-central2-docker.pkg.dev/tpu-prod-env-one-vm/camilo-tpu/pw-arc-python:latest
         JOBSET_HEALTHY_TIMEOUT: 2100
         ACCELERATOR: v6e_4x4_2
         # Optional flags
@@ -47,7 +47,7 @@ jobs:
   interruption-jobset-replica-resize:
     runs-on: jobset
     container:
-      image: us-central2-docker.pkg.dev/tpu-prod-env-one-vm/camilo-tpu/pw-arc-jobset-replica:latest
+      image: us-central2-docker.pkg.dev/tpu-prod-env-one-vm/camilo-tpu/pw-arc-jobset:latest
       env:
         # Required environmental variables for a successful run
         JOBSET_HEALTHY_TIMEOUT: 2100

--- a/.github/workflows/pw-elastic-replica-resize-test.yaml
+++ b/.github/workflows/pw-elastic-replica-resize-test.yaml
@@ -1,4 +1,4 @@
-name: pw-mult-elastic-training-test
+name: pw-elastic-replica-resize-training-test
 on:
   workflow_dispatch
 jobs:
@@ -12,7 +12,7 @@ jobs:
         ARC_JOBSET_JSON: /var/arc/arc-pw-elastic.json
         GCS_PREFIX: gs://axlearn-arc-testing/testing
         JOBSET_DOCKER_IMAGE: us-central2-docker.pkg.dev/tpu-prod-env-one-vm/camilo-tpu/pw-arc-python-replica:latest
-        JOBSET_HEALTHY_TIMEOUT: 2000
+        JOBSET_HEALTHY_TIMEOUT: 2100
         ACCELERATOR: v6e_4x4_2
         # Optional flags
         STEPS_CHECKPOINT: 20
@@ -20,14 +20,11 @@ jobs:
         RESTORE_MODE: True
         # RESTORE_MODE: True
         CUSTOM_GIT_ORIGIN: https://github.com/Borklet-Labs/axlearn
-        CUSTOM_GIT_BRANCH: cienet/replica_resize # Customize with a different branch
-
+        CUSTOM_GIT_BRANCH: cienet/0_10_dev # Customize with a different branch
         PW_PROXY_IMAGE: us-docker.pkg.dev/cloud-tpu-v2-images/pathways/proxy_server:20260501-jax_0.10.0
         PW_SERVER_IMAGE: us-docker.pkg.dev/cloud-tpu-v2-images/pathways/server:20260501-jax_0.10.0
         POST_SETUP_CMD: pip install importlib_resources && pip install jax==0.10.0 jaxlib==0.10.0 -i https://us-python.pkg.dev/ml-oss-artifacts-published/jax/simple/ --extra-index-url https://pypi.org/simple || echo setup_failed
 
-        # PW_PROXY_IMAGE: us-docker.pkg.dev/cloud-tpu-v2-images/pathways/proxy_server:20260206-jax_0.8.2
-        # PW_SERVER_IMAGE: us-docker.pkg.dev/cloud-tpu-v2-images/pathways/server:20260206-jax_0.8.2
     steps:
       - name: Install the Kubernetes Python SDK
         run: uv pip install kubernetes
@@ -52,7 +49,7 @@ jobs:
       image: us-central2-docker.pkg.dev/tpu-prod-env-one-vm/camilo-tpu/pw-arc-jobset-replica:latest
       env:
         # Required environmental variables for a successful run
-        JOBSET_HEALTHY_TIMEOUT: 2000
+        JOBSET_HEALTHY_TIMEOUT: 2100
         CUSTOM_GIT_BRANCH: main # Customize with a different branch
         GCS_PREFIX: gs://axlearn-arc-testing/testing
     steps:

--- a/.github/workflows/pw-multislice-elastic-test.yaml
+++ b/.github/workflows/pw-multislice-elastic-test.yaml
@@ -19,8 +19,8 @@ jobs:
         MAX_STEPS: 100
         DELETE_MODE: node
         RESTORE_MODE: True
-        CUSTOM_GIT_ORIGIN: https://github.com/Borklet-Labs/axlearn
-        CUSTOM_GIT_BRANCH: cienet/replica_resize # Customize with a different branch
+        CUSTOM_GIT_ORIGIN: https://github.com/lkolluru05/axlearn
+        CUSTOM_GIT_BRANCH: elastic_training # Customize with a different branch
         # JOBSET_MAX_RESTARTS: 1 # Allow restarts in the JobSet. Default = 0 (no restarts)
         # SCHEDULE_TIMEOUT: 600 # Seconds to wait for job to be scheduled. Default = 900
         # FUJI_PATCH_FILE: /var/arc/fuji-main.patch # Path to a patch for axlearn/experiments/text/gpt/fuji.py

--- a/.github/workflows/pw-multislice-elastic-test.yaml
+++ b/.github/workflows/pw-multislice-elastic-test.yaml
@@ -18,9 +18,9 @@ jobs:
         STEPS_CHECKPOINT: 20
         MAX_STEPS: 100
         DELETE_MODE: node
-        RESTORE_MODE: True
-        CUSTOM_GIT_ORIGIN: https://github.com/lkolluru05/axlearn
-        CUSTOM_GIT_BRANCH: elastic_training # Customize with a different branch
+        # RESTORE_MODE: True
+        CUSTOM_GIT_ORIGIN: https://github.com/Borklet-Labs/axlearn
+        CUSTOM_GIT_BRANCH: cienet/replica_resize # Customize with a different branch
         # JOBSET_MAX_RESTARTS: 1 # Allow restarts in the JobSet. Default = 0 (no restarts)
         # SCHEDULE_TIMEOUT: 600 # Seconds to wait for job to be scheduled. Default = 900
         # FUJI_PATCH_FILE: /var/arc/fuji-main.patch # Path to a patch for axlearn/experiments/text/gpt/fuji.py
@@ -57,35 +57,35 @@ jobs:
         run: GH_RUN_ID=${{ github.run_id }} bash /var/arc/upload-result.sh
 
 
-  interruption-jobset:
-    runs-on: jobset
-    container:
-      image: us-central2-docker.pkg.dev/tpu-prod-env-one-vm/camilo-tpu/pw-arc-jobset:latest
-      env:
-        # Required environmental variables for a successful run
-        JOBSET_HEALTHY_TIMEOUT: 2400
-        CUSTOM_GIT_BRANCH: main # Customize with a different branch
-        GCS_PREFIX: gs://axlearn-arc-testing/testing
-    steps:
-      - name: Install the Kubernetes Python SDK
-        run: |
-          uv pip install kubernetes
-      - name: Launch Node deletion
-        id: launch_deletion
-        env:
-          GH_RUN_ID: ${{ github.run_id }}
-          ARC_JOBSET_NAME_TARGET: arc-pw-elastic-training
-          DELETE_MODE: node
-        run: |
-          START_TIME=$(date +%s)
-          echo "START_TIME=$START_TIME" >> $GITHUB_ENV
-          DELETE_MODE=node START_TIME=$START_TIME GH_RUN_ID=${{ github.run_id }} python /var/arc/validation_utils.py
-          echo "start_time=$START_TIME" >> $GITHUB_OUTPUT
-      - name: Launch the restore Validation
-        env:
-          GH_RUN_ID: ${{ github.run_id }}
-          START_TIME: ${{ steps.launch_deletion.outputs.start_time}}
-          ARC_JOBSET_NAME_TARGET: arc-pw-elastic-training
-          VALIDATION_METHOD: restore
-        run: |
-          START_TIME=$START_TIME GH_RUN_ID=${{ github.run_id }} python /var/arc/validation_utils.py
+  # interruption-jobset:
+  #   runs-on: jobset
+  #   container:
+  #     image: us-central2-docker.pkg.dev/tpu-prod-env-one-vm/camilo-tpu/pw-arc-jobset-replica:latest
+  #     env:
+  #       # Required environmental variables for a successful run
+  #       JOBSET_HEALTHY_TIMEOUT: 2400
+  #       CUSTOM_GIT_BRANCH: main # Customize with a different branch
+  #       GCS_PREFIX: gs://axlearn-arc-testing/testing
+  #   steps:
+  #     - name: Install the Kubernetes Python SDK
+  #       run: |
+  #         uv pip install kubernetes
+  #     - name: Launch Node deletion
+  #       id: launch_deletion
+  #       env:
+  #         GH_RUN_ID: ${{ github.run_id }}
+  #         ARC_JOBSET_NAME_TARGET: arc-pw-elastic-training
+  #         DELETE_MODE: node
+  #       run: |
+  #         START_TIME=$(date +%s)
+  #         echo "START_TIME=$START_TIME" >> $GITHUB_ENV
+  #         DELETE_MODE=node START_TIME=$START_TIME GH_RUN_ID=${{ github.run_id }} python /var/arc/validation_utils.py
+  #         echo "start_time=$START_TIME" >> $GITHUB_OUTPUT
+  #     - name: Launch the restore Validation
+  #       env:
+  #         GH_RUN_ID: ${{ github.run_id }}
+  #         START_TIME: ${{ steps.launch_deletion.outputs.start_time}}
+  #         ARC_JOBSET_NAME_TARGET: arc-pw-elastic-training
+  #         VALIDATION_METHOD: restore
+  #       run: |
+  #         START_TIME=$START_TIME GH_RUN_ID=${{ github.run_id }} python /var/arc/validation_utils.py

--- a/.github/workflows/pw-multislice-elastic-test.yaml
+++ b/.github/workflows/pw-multislice-elastic-test.yaml
@@ -5,13 +5,13 @@ jobs:
   pw-tpu-single-slice-training-test-job:
     runs-on: jobset # Runs on CPU because this schedules a JobSet that's later routed to TPU
     container:
-      image: us-central2-docker.pkg.dev/tpu-prod-env-one-vm/camilo-tpu/pw-arc-jobset:latest
+      image: us-central2-docker.pkg.dev/tpu-prod-env-one-vm/camilo-tpu/pw-arc-jobset-replica:latest
       env:
         # Required environmental variables for a successful run
         ARC_JOBSET_NAME: arc-pw-elastic-training
         ARC_JOBSET_JSON: /var/arc/arc-pw-elastic.json
         GCS_PREFIX: gs://axlearn-arc-testing/testing
-        JOBSET_DOCKER_IMAGE: us-central2-docker.pkg.dev/tpu-prod-env-one-vm/camilo-tpu/pw-arc-python:latest
+        JOBSET_DOCKER_IMAGE: us-central2-docker.pkg.dev/tpu-prod-env-one-vm/camilo-tpu/pw-arc-python-replica:latest
         JOBSET_HEALTHY_TIMEOUT: 3200
         ACCELERATOR: v6e_4x4_2
         # Optional flags
@@ -20,7 +20,7 @@ jobs:
         DELETE_MODE: node
         RESTORE_MODE: True
         CUSTOM_GIT_ORIGIN: https://github.com/Borklet-Labs/axlearn
-        CUSTOM_GIT_BRANCH: cienet/elastic_dev # Customize with a different branch
+        CUSTOM_GIT_BRANCH: cienet/replica_resize # Customize with a different branch
         # JOBSET_MAX_RESTARTS: 1 # Allow restarts in the JobSet. Default = 0 (no restarts)
         # SCHEDULE_TIMEOUT: 600 # Seconds to wait for job to be scheduled. Default = 900
         # FUJI_PATCH_FILE: /var/arc/fuji-main.patch # Path to a patch for axlearn/experiments/text/gpt/fuji.py

--- a/.github/workflows/pw-multislice-elastic-test.yaml
+++ b/.github/workflows/pw-multislice-elastic-test.yaml
@@ -2,7 +2,7 @@ name: pw-mult-elastic-training-test
 on:
   workflow_dispatch
 jobs:
-  pw-tpu-single-slice-training-test-job:
+  pw-elastic-replica-resize-training-test-job:
     runs-on: jobset # Runs on CPU because this schedules a JobSet that's later routed to TPU
     container:
       image: us-central2-docker.pkg.dev/tpu-prod-env-one-vm/camilo-tpu/pw-arc-jobset-replica:latest
@@ -12,12 +12,12 @@ jobs:
         ARC_JOBSET_JSON: /var/arc/arc-pw-elastic.json
         GCS_PREFIX: gs://axlearn-arc-testing/testing
         JOBSET_DOCKER_IMAGE: us-central2-docker.pkg.dev/tpu-prod-env-one-vm/camilo-tpu/pw-arc-python-replica:latest
-        JOBSET_HEALTHY_TIMEOUT: 3200
+        JOBSET_HEALTHY_TIMEOUT: 2000
         ACCELERATOR: v6e_4x4_2
         # Optional flags
         STEPS_CHECKPOINT: 20
         MAX_STEPS: 100
-        DELETE_MODE: node
+        RESTORE_MODE: True
         # RESTORE_MODE: True
         CUSTOM_GIT_ORIGIN: https://github.com/Borklet-Labs/axlearn
         CUSTOM_GIT_BRANCH: cienet/replica_resize # Customize with a different branch
@@ -44,49 +44,38 @@ jobs:
 
           echo "start_time=$START_TIME" >> $GITHUB_OUTPUT
           echo "end_time=$END_TIME" >> $GITHUB_OUTPUT
-      - name: Checkpoint Validation
-        if: always()
+
+
+  interruption-jobset-replica-resize:
+    runs-on: jobset
+    container:
+      image: us-central2-docker.pkg.dev/tpu-prod-env-one-vm/camilo-tpu/pw-arc-jobset-replica:latest
+      env:
+        # Required environmental variables for a successful run
+        JOBSET_HEALTHY_TIMEOUT: 2000
+        CUSTOM_GIT_BRANCH: main # Customize with a different branch
+        GCS_PREFIX: gs://axlearn-arc-testing/testing
+    steps:
+      - name: Install the Kubernetes Python SDK
+        run: |
+          uv pip install kubernetes
+      - name: Launch Node deletion
+        id: launch_deletion
         env:
           GH_RUN_ID: ${{ github.run_id }}
-          START_TIME: ${{ steps.launch_step.outputs.start_time}}
-          END_TIME: ${{ steps.launch_step.outputs.end_time}}
-          VALIDATION_METHOD: save
+          ARC_JOBSET_NAME_TARGET: arc-pw-elastic-training
+          DELETE_MODE: drain
         run: |
-          python /var/arc/validation_utils.py
-      - name: Upload the training result to GCS
-        if: always()
-        run: GH_RUN_ID=${{ github.run_id }} bash /var/arc/upload-result.sh
-
-
-  # interruption-jobset:
-  #   runs-on: jobset
-  #   container:
-  #     image: us-central2-docker.pkg.dev/tpu-prod-env-one-vm/camilo-tpu/pw-arc-jobset-replica:latest
-  #     env:
-  #       # Required environmental variables for a successful run
-  #       JOBSET_HEALTHY_TIMEOUT: 2400
-  #       CUSTOM_GIT_BRANCH: main # Customize with a different branch
-  #       GCS_PREFIX: gs://axlearn-arc-testing/testing
-  #   steps:
-  #     - name: Install the Kubernetes Python SDK
-  #       run: |
-  #         uv pip install kubernetes
-  #     - name: Launch Node deletion
-  #       id: launch_deletion
-  #       env:
-  #         GH_RUN_ID: ${{ github.run_id }}
-  #         ARC_JOBSET_NAME_TARGET: arc-pw-elastic-training
-  #         DELETE_MODE: node
-  #       run: |
-  #         START_TIME=$(date +%s)
-  #         echo "START_TIME=$START_TIME" >> $GITHUB_ENV
-  #         DELETE_MODE=node START_TIME=$START_TIME GH_RUN_ID=${{ github.run_id }} python /var/arc/validation_utils.py
-  #         echo "start_time=$START_TIME" >> $GITHUB_OUTPUT
-  #     - name: Launch the restore Validation
-  #       env:
-  #         GH_RUN_ID: ${{ github.run_id }}
-  #         START_TIME: ${{ steps.launch_deletion.outputs.start_time}}
-  #         ARC_JOBSET_NAME_TARGET: arc-pw-elastic-training
-  #         VALIDATION_METHOD: restore
-  #       run: |
-  #         START_TIME=$START_TIME GH_RUN_ID=${{ github.run_id }} python /var/arc/validation_utils.py
+          START_TIME=$(date +%s)
+          echo "START_TIME=$START_TIME" >> $GITHUB_ENV
+          START_TIME=$START_TIME GH_RUN_ID=${{ github.run_id }} python /var/arc/validation_utils.py
+          echo "start_time=$START_TIME" >> $GITHUB_OUTPUT
+      - name: Launch the restore Validation
+        env:
+          GH_RUN_ID: ${{ github.run_id }}
+          START_TIME: ${{ steps.launch_deletion.outputs.start_time}}
+          ARC_JOBSET_NAME_TARGET: arc-pw-elastic-training
+          VALIDATION_METHOD: restore
+          MIN_SLICES: 1
+        run: |
+          START_TIME=$START_TIME GH_RUN_ID=${{ github.run_id }} python /var/arc/validation_utils.py

--- a/.github/workflows/pw-multislice-elastic-test.yaml
+++ b/.github/workflows/pw-multislice-elastic-test.yaml
@@ -21,12 +21,13 @@ jobs:
         # RESTORE_MODE: True
         CUSTOM_GIT_ORIGIN: https://github.com/Borklet-Labs/axlearn
         CUSTOM_GIT_BRANCH: cienet/replica_resize # Customize with a different branch
-        # JOBSET_MAX_RESTARTS: 1 # Allow restarts in the JobSet. Default = 0 (no restarts)
-        # SCHEDULE_TIMEOUT: 600 # Seconds to wait for job to be scheduled. Default = 900
-        # FUJI_PATCH_FILE: /var/arc/fuji-main.patch # Path to a patch for axlearn/experiments/text/gpt/fuji.py
-        # ENABLE_JAX_DEV: # Set this to true to enable prereleases in uv and reference the Jax index
-        PW_PROXY_IMAGE: us-docker.pkg.dev/cloud-tpu-v2-images/pathways/proxy_server:20260206-jax_0.8.2
-        PW_SERVER_IMAGE: us-docker.pkg.dev/cloud-tpu-v2-images/pathways/server:20260206-jax_0.8.2
+
+        PW_PROXY_IMAGE: us-docker.pkg.dev/cloud-tpu-v2-images/pathways/proxy_server:20260501-jax_0.10.0
+        PW_SERVER_IMAGE: us-docker.pkg.dev/cloud-tpu-v2-images/pathways/server:20260501-jax_0.10.0
+        POST_SETUP_CMD: pip install importlib_resources && pip install jax==0.10.0 jaxlib==0.10.0 -i https://us-python.pkg.dev/ml-oss-artifacts-published/jax/simple/ --extra-index-url https://pypi.org/simple || echo setup_failed
+
+        # PW_PROXY_IMAGE: us-docker.pkg.dev/cloud-tpu-v2-images/pathways/proxy_server:20260206-jax_0.8.2
+        # PW_SERVER_IMAGE: us-docker.pkg.dev/cloud-tpu-v2-images/pathways/server:20260206-jax_0.8.2
     steps:
       - name: Install the Kubernetes Python SDK
         run: uv pip install kubernetes

--- a/.github/workflows/pw-multislice-training-test.yaml
+++ b/.github/workflows/pw-multislice-training-test.yaml
@@ -23,8 +23,12 @@ jobs:
         # SCHEDULE_TIMEOUT: 600 # Seconds to wait for job to be scheduled. Default = 900
         # FUJI_PATCH_FILE: /var/arc/fuji-main.patch # Path to a patch for axlearn/experiments/text/gpt/fuji.py
         # ENABLE_JAX_DEV: # Set this to true to enable prereleases in uv and reference the Jax index
-        PW_PROXY_IMAGE: us-docker.pkg.dev/cloud-tpu-v2-images/pathways/proxy_server:20260206-jax_0.8.2
-        PW_SERVER_IMAGE: us-docker.pkg.dev/cloud-tpu-v2-images/pathways/server:20260206-jax_0.8.2
+        CUSTOM_GIT_ORIGIN: https://github.com/Borklet-Labs/axlearn
+        CUSTOM_GIT_BRANCH: cienet/elastic_training # Customize with a different branch
+
+        PW_PROXY_IMAGE: us-docker.pkg.dev/cloud-tpu-v2-images/pathways/proxy_server:20260501-jax_0.10.0
+        PW_SERVER_IMAGE: us-docker.pkg.dev/cloud-tpu-v2-images/pathways/server:20260501-jax_0.10.0
+        POST_SETUP_CMD: pip install importlib_resources && pip install jax==0.10.0 jaxlib==0.10.0 -i https://us-python.pkg.dev/ml-oss-artifacts-published/jax/simple/ --extra-index-url https://pypi.org/simple || echo setup_failed
     steps:
       - name: Install the Kubernetes Python SDK
         run: uv pip install kubernetes

--- a/.github/workflows/pw-single-slice-training-restore.yaml
+++ b/.github/workflows/pw-single-slice-training-restore.yaml
@@ -27,8 +27,12 @@ jobs:
         # POST_SETUP_CMD: uv pip install libtpu==0.0.32.2
         # FUJI_PATCH_FILE: /var/arc/fuji-main.patch # Path to a patch for axlearn/experiments/text/gpt/fuji.py
         # ENABLE_JAX_DEV: # Set this to true to enable prereleases in uv and reference the Jax index
-        PW_PROXY_IMAGE: us-docker.pkg.dev/cloud-tpu-v2-images/pathways/proxy_server:20260206-jax_0.8.2
-        PW_SERVER_IMAGE: us-docker.pkg.dev/cloud-tpu-v2-images/pathways/server:20260206-jax_0.8.2
+        CUSTOM_GIT_ORIGIN: https://github.com/Borklet-Labs/axlearn
+        CUSTOM_GIT_BRANCH: cienet/elastic_training # Customize with a different branch
+
+        PW_PROXY_IMAGE: us-docker.pkg.dev/cloud-tpu-v2-images/pathways/proxy_server:20260501-jax_0.10.0
+        PW_SERVER_IMAGE: us-docker.pkg.dev/cloud-tpu-v2-images/pathways/server:20260501-jax_0.10.0
+        POST_SETUP_CMD: pip install importlib_resources && pip install jax==0.10.0 jaxlib==0.10.0 -i https://us-python.pkg.dev/ml-oss-artifacts-published/jax/simple/ --extra-index-url https://pypi.org/simple || echo setup_failed
     steps:
       - name: Install the Kubernetes Python SDK
         run: uv pip install kubernetes

--- a/.github/workflows/pw-single-slice-training-test.yaml
+++ b/.github/workflows/pw-single-slice-training-test.yaml
@@ -16,7 +16,7 @@ jobs:
         ACCELERATOR: v6e_4x4_1
         # Optional flags
         STEPS_CHECKPOINT: 50
-        MAX_STEPS: 500
+        MAX_STEPS: 100
         # POST_SETUP_CMD: uv pip install jax==0.9.0
         # CUSTOM_GIT_ORIGIN: https://github.com/CIeNET-International/axlearn # Optionally point to another repo
         # CUSTOM_GIT_BRANCH: cienet_jax_py3.12_nightly

--- a/.github/workflows/pw-single-slice-training-test.yaml
+++ b/.github/workflows/pw-single-slice-training-test.yaml
@@ -26,8 +26,6 @@ jobs:
         # SCHEDULE_TIMEOUT: 600 # Seconds to wait for job to be scheduled. Default = 900
         # FUJI_PATCH_FILE: /var/arc/fuji-main.patch # Path to a patch for axlearn/experiments/text/gpt/fuji.py
         # ENABLE_JAX_DEV: # Set this to true to enable prereleases in uv and reference the Jax index
-        CUSTOM_GIT_ORIGIN: https://github.com/Borklet-Labs/axlearn
-        CUSTOM_GIT_BRANCH: cienet/elastic_training # Customize with a different branch
 
         PW_PROXY_IMAGE: us-docker.pkg.dev/cloud-tpu-v2-images/pathways/proxy_server:20260501-jax_0.10.0
         PW_SERVER_IMAGE: us-docker.pkg.dev/cloud-tpu-v2-images/pathways/server:20260501-jax_0.10.0

--- a/.github/workflows/pw-single-slice-training-test.yaml
+++ b/.github/workflows/pw-single-slice-training-test.yaml
@@ -26,8 +26,12 @@ jobs:
         # SCHEDULE_TIMEOUT: 600 # Seconds to wait for job to be scheduled. Default = 900
         # FUJI_PATCH_FILE: /var/arc/fuji-main.patch # Path to a patch for axlearn/experiments/text/gpt/fuji.py
         # ENABLE_JAX_DEV: # Set this to true to enable prereleases in uv and reference the Jax index
-        PW_PROXY_IMAGE: us-docker.pkg.dev/cloud-tpu-v2-images/pathways/proxy_server:20260206-jax_0.8.2
-        PW_SERVER_IMAGE: us-docker.pkg.dev/cloud-tpu-v2-images/pathways/server:20260206-jax_0.8.2
+        CUSTOM_GIT_ORIGIN: https://github.com/Borklet-Labs/axlearn
+        CUSTOM_GIT_BRANCH: cienet/elastic_training # Customize with a different branch
+
+        PW_PROXY_IMAGE: us-docker.pkg.dev/cloud-tpu-v2-images/pathways/proxy_server:20260501-jax_0.10.0
+        PW_SERVER_IMAGE: us-docker.pkg.dev/cloud-tpu-v2-images/pathways/server:20260501-jax_0.10.0
+        POST_SETUP_CMD: pip install importlib_resources && pip install jax==0.10.0 jaxlib==0.10.0 -i https://us-python.pkg.dev/ml-oss-artifacts-published/jax/simple/ --extra-index-url https://pypi.org/simple || echo setup_failed
     steps:
       - name: Install the Kubernetes Python SDK
         run: uv pip install kubernetes

--- a/jobset/arc-pw-elastic.json
+++ b/jobset/arc-pw-elastic.json
@@ -92,7 +92,7 @@
                       { "name": "DELETE_MODE", "value": "INSERT_DELETE_MODE" },
                       { "name": "VALIDATION_METHOD", "value": "INSERT_VALIDATION_METHOD" },
                       { "name": "NUM_REPLICAS", "value": "2" },
-                      { "name": "ELASTIC_MODE", "value": "replica-resize" },
+                      { "name": "ENABLED_REPLICA_RESIZE", "value": "INSERT_ENABLE_REPLICA_RESIZE" },
 
                       {
                         "name": "REPLICA_ID",

--- a/jobset/arc-pw-elastic.json
+++ b/jobset/arc-pw-elastic.json
@@ -28,7 +28,7 @@
           "metadata": {
             "annotations": {
               "axlearn/replicatedjob-load-balancer-port": "80",
-              "axlearn/replicatedjob-load-balancer-service-name": "arc-pw-elstic-training-pwhd-service",
+
               "axlearn/replicatedjob-load-balancer-target-port": "9000"
             }
           },
@@ -89,8 +89,11 @@
                       { "name": "ENABLE_JAX_DEV", "value": "INSERT_ENABLE_JAX_DEV" },
                       { "name": "MAX_STEPS", "value": "INSERT_MAX_STEPS" },
                       { "name": "STEPS_CHECKPOINT", "value": "INSERT_STEPS_CHECKPOINT" },
+                      { "name": "DELETE_MODE", "value": "INSERT_DELETE_MODE" },
+                      { "name": "VALIDATION_METHOD", "value": "INSERT_VALIDATION_METHOD" },
                       { "name": "NUM_REPLICAS", "value": "2" },
                       { "name": "ELASTIC_MODE", "value": "replica-resize" },
+
                       {
                         "name": "REPLICA_ID",
                         "valueFrom": { "fieldRef": { "fieldPath": "metadata.annotations['jobset.sigs.k8s.io/job-index']" } }

--- a/jobset/arc-pw-elastic.json
+++ b/jobset/arc-pw-elastic.json
@@ -90,6 +90,7 @@
                       { "name": "MAX_STEPS", "value": "INSERT_MAX_STEPS" },
                       { "name": "STEPS_CHECKPOINT", "value": "INSERT_STEPS_CHECKPOINT" },
                       { "name": "NUM_REPLICAS", "value": "2" },
+                      { "name": "ELASTIC_MODE", "value": "replica-resize" },
                       {
                         "name": "REPLICA_ID",
                         "valueFrom": { "fieldRef": { "fieldPath": "metadata.annotations['jobset.sigs.k8s.io/job-index']" } }

--- a/jobset/arc-pw-single-elastic.json
+++ b/jobset/arc-pw-single-elastic.json
@@ -90,6 +90,8 @@
                       { "name": "MAX_STEPS", "value": "INSERT_MAX_STEPS" },
                       { "name": "STEPS_CHECKPOINT", "value": "INSERT_STEPS_CHECKPOINT" },
                        { "name": "NUM_REPLICAS", "value": "1" },
+                      { "name": "ENABLED_PAUSE_RESUME", "value": "INSERT_ENABLE_PAUSE_RESUME" },
+
                       {
                         "name": "REPLICA_ID",
                         "valueFrom": { "fieldRef": { "fieldPath": "metadata.annotations['jobset.sigs.k8s.io/job-index']" } }

--- a/jobset/launch_jobset.py
+++ b/jobset/launch_jobset.py
@@ -39,6 +39,8 @@ MAX_STEPS = os.environ['MAX_STEPS'] if "MAX_STEPS" in os.environ else None
 STEPS_CHECKPOINT = os.environ['STEPS_CHECKPOINT'] if "STEPS_CHECKPOINT" in os.environ else None
 
 
+
+
 # Use the dynamic client to leverage the JobSet API
 CLIENT = kubernetes.dynamic.DynamicClient(
     kubernetes.client.ApiClient(

--- a/jobset/launch_jobset.py
+++ b/jobset/launch_jobset.py
@@ -19,7 +19,7 @@ import signal
 import threading
 import kubernetes
 
-# Get the JobSet info from the environment
+# Baseline Mcjax training jobset
 JOBSET_NAME = os.environ['ARC_JOBSET_NAME']
 JOBSET_JSON = os.environ['ARC_JOBSET_JSON']
 DOCKER_IMAGE = os.environ['JOBSET_DOCKER_IMAGE']
@@ -30,13 +30,23 @@ SCHEDULE_TIMEOUT = int(os.environ['SCHEDULE_TIMEOUT']) if "SCHEDULE_TIMEOUT" in 
 POST_SETUP_CMD = os.environ['POST_SETUP_CMD'] if "POST_SETUP_CMD" in os.environ else None
 FUJI_PATCH_FILE = os.environ['FUJI_PATCH_FILE'] if "FUJI_PATCH_FILE" in os.environ else None
 ENABLE_JAX_DEV = os.environ['ENABLE_JAX_DEV'] if "ENABLE_JAX_DEV" in os.environ else None
+
+# Pathways Testing
 PW_PROXY_IMAGE = os.environ['PW_PROXY_IMAGE'] if "PW_PROXY_IMAGE" in os.environ else None
 PW_SERVER_IMAGE = os.environ['PW_SERVER_IMAGE'] if "PW_SERVER_IMAGE" in os.environ else None
+
+# Pathways + Elastic Training
+ENABLED_PAUSE_RESUME = os.environ['ENABLED_PAUSE_RESUME'] if "ENABLED_PAUSE_RESUME" in os.environ else None
+ENABLED_REPLICA_RESIZE = os.environ['ENABLED_REPLICA_RESIZE'] if "ENABLED_REPLICA_RESIZE" in os.environ else None
 RESTORE_MODE = os.environ['RESTORE_MODE'] if "RESTORE_MODE" in os.environ else None
+
+# Pathways + Colocated Python
 COLOCATED_PY_IMAGE = os.environ['COLOCATED_PY_IMAGE'] if "COLOCATED_PY_IMAGE" in os.environ else None
 BENCHMARK_MODE = os.environ['BENCHMARK_MODE'] if "BENCHMARK_MODE" in os.environ else None
 MAX_STEPS = os.environ['MAX_STEPS'] if "MAX_STEPS" in os.environ else None
 STEPS_CHECKPOINT = os.environ['STEPS_CHECKPOINT'] if "STEPS_CHECKPOINT" in os.environ else None
+
+
 
 
 
@@ -303,6 +313,16 @@ def update_jobset(jobset_base_config: dict) -> dict:
     if FUJI_PATCH_FILE:
         print(f'Detected fuji mesh selector patch at: {FUJI_PATCH_FILE}', file=sys.stderr)
         updated_jobset = updated_jobset.replace("INSERT_FUJI_PATCH_FILE", FUJI_PATCH_FILE)
+
+    # Enabled Replica Resize mode
+    if ENABLED_REPLICA_RESIZE:
+        print(f'Detected Replica Resize mode enabled: {ENABLED_REPLICA_RESIZE}', file=sys.stderr)
+        updated_jobset = updated_jobset.replace("ENABLED_PAUSE_RESUME", ENABLED_REPLICA_RESIZE)
+
+    # Enabled Pause and Resume mode
+    if ENABLED_PAUSE_RESUME:
+        print(f'Detected Pause and Resume : {ENABLED_PAUSE_RESUME}', file=sys.stderr)
+        updated_jobset = updated_jobset.replace("INSERT_ENABLED_PAUSE_RESUME", ENABLED_PAUSE_RESUME)
 
     # Enable pre-release Jax dev mode
     if ENABLE_JAX_DEV:

--- a/jobset/validation_utils.py
+++ b/jobset/validation_utils.py
@@ -364,8 +364,8 @@ if __name__ == '__main__':
   # TODO: Need to pass this variable from the yaml file.
   # This is the target step we are aiming for deleting the pod and
   # validating the restored step checkpoint.
-  deletion_target_step = 55
-  restore_step_target= 50
+  deletion_target_step = 25
+  restore_step_target= 20
   if JOBSET_NAME_TARGET == "arc-pw-ss-elastic-training":
     deletion_target_step = 105
     restore_step_target= 100
@@ -381,7 +381,8 @@ if __name__ == '__main__':
     while time_elapsed < JOBSET_HEALTHY_TIMEOUT:
       now = str(int(datetime.now(timezone.utc).timestamp()))
       start_dt, end_dt = convert_unix_timestamps(start_time=START_TIME, end_time=now)
-      log_pattern = rf"gpt_trainer\s+process\s+\d+\s+step\s+{deletion_target_step}\]"
+      print("On new image..........")
+      log_pattern = rf"gpt_trainer\s+process\s+\d+\s+step\s+{deletion_target_step}\s+\]"
       complied_pattern = re.compile(log_pattern)
       # Fetch logs from Cloud Logging API for the specified time window.
       entries = list_log_entries(
@@ -474,7 +475,3 @@ if __name__ == '__main__':
       print(f"[{time_elapsed}/{JOBSET_HEALTHY_TIMEOUT}]: Waiting for all pods to be Running...", file=sys.stderr)
       time.sleep(60)
       time_elapsed += 60
-
-
-
-

--- a/jobset/validation_utils.py
+++ b/jobset/validation_utils.py
@@ -49,6 +49,8 @@ GCS_PREFIX = os.environ['GCS_PREFIX'] if "GCS_PREFIX" in os.environ else None
 GIT_BRANCH = os.environ['CUSTOM_GIT_BRANCH'] if "CUSTOM_GIT_BRANCH" in os.environ else "main"
 VALIDATION_METHOD = os.environ['VALIDATION_METHOD'] if "VALIDATION_METHOD" in os.environ else None
 DELETE_MODE= os.environ['DELETE_MODE'] if "DELETE_MODE" in os.environ else None
+MIN_SLICES = os.environ['MIN_SLICES'] if "MIN_SLICES" in os.environ else None
+
 
 
 # Use the dynamic client to leverage the JobSet API
@@ -453,8 +455,8 @@ def validate_restore(target_step: int, start_time: Optional[datetime] = None, en
         bool: True if validation succeeds.
     """
 
-    pod_name_pattern =  "arc-pw-ss-elastic-training-pwhd-0-.*" if JOBSET_NAME_TARGET == "arc-pw-ss-elastic-training" else "arc-pw-training-pwhd-0-.*"
     # We need to pass a <step> group so it can return the chckp step found.
+    pod_name_pattern =  ".*-elastic-training-pwhd-0-.*" if "elastic" in JOBSET_NAME_TARGET else "arc-pw-training-pwhd-0-.*"
     restore_pattern = r"Restoring.*step_(?P<step>\d{8})"
     chkp_in_logs = extract_log_metrics(log_pattern=restore_pattern, pod_pattern=pod_name_pattern, start_time=start_time, end_time=end_time)
     print(f"Checkpoints found on Restore: {list(chkp_in_logs)}")
@@ -469,6 +471,11 @@ if __name__ == '__main__':
   # TODO: Need to pass this variable from the yaml file.
   # This is the target step we are aiming for deleting the pod and
   # validating the restored step checkpoint.
+
+  print(f"DELETE_MODE: {DELETE_MODE}", file=sys.stderr)
+  print(f"VALIDATION METHOD: {VALIDATION_METHOD}", file=sys.stderr)
+  print(f"MIN_SLICES: {MIN_SLICES}", file=sys.stderr)
+
   deletion_target_step = 25
   restore_step_target= 20
   if JOBSET_NAME_TARGET == "arc-pw-ss-elastic-training":
@@ -488,7 +495,6 @@ if __name__ == '__main__':
     while time_elapsed < JOBSET_HEALTHY_TIMEOUT:
       now = str(int(datetime.now(timezone.utc).timestamp()))
       start_dt, end_dt = convert_unix_timestamps(start_time=START_TIME, end_time=now)
-      print("On new image..........")
       log_pattern = rf"gpt_trainer\s+process\s+\d+\s+step\s+{deletion_target_step}\s+\]"
       complied_pattern = re.compile(log_pattern)
       # Fetch logs from Cloud Logging API for the specified time window.
@@ -510,11 +516,11 @@ if __name__ == '__main__':
           sys.exit(0)
         elif DELETE_MODE == "drain":
           print(f"Target step {deletion_target_step} reached. Triggering node drain...", file=sys.stderr)
-          drain_nodes_pw(dry_run=True)
+          drain_nodes_pw(dry_run=False)
           sys.exit(0)
       print(f"[{time_elapsed}/{JOBSET_HEALTHY_TIMEOUT}]: Waiting for target step {deletion_target_step} in logs...", file=sys.stderr)
-      time.sleep(60)
-      time_elapsed += 60
+      time.sleep(30)
+      time_elapsed += 30
     raise ValueError(f"Timeout reached: Target step {deletion_target_step} not found in logs "
               f"within {JOBSET_HEALTHY_TIMEOUT} seconds.")
 
@@ -564,8 +570,11 @@ if __name__ == '__main__':
       )
 
       # We need to check that all pods 'axlearn-arc' namespace  are in RUNNING state.
-      all_running = all(pod.status.phase == "Running" for pod in pods_pw.items)
-      if all_running and len(pods_pw.items) > 0:
+      # For Elastic Training Replica Resize we only need to wait for MIN_SLICES to be up.
+      pods_targets = [pod for pod in pods_pw.items if "pwwk-1" in pod.metadata.name] if MIN_SLICES else pods_pw.items
+      all_running = bool(pods_targets) and all(pod.status.phase == "Running" for pod in pods_targets)
+
+      if all_running and len(pods_targets) > 0:
           print(f"All pods for {JOBSET_NAME_TARGET} are Running. Proceeding with restore validation.", file=sys.stderr)
 
           # We need to give time so the restoring logs appear in the pw-head

--- a/jobset/validation_utils.py
+++ b/jobset/validation_utils.py
@@ -97,6 +97,111 @@ def delete_node_pw(dry_run: bool = False):
     sys.exit(1)
 
 
+def drain_nodes_pw(dry_run: bool = False):
+    """ Drain Pathways worker nodes by cordoning and evicting pods.
+    Args:
+        dry_run: If True, only print the operations that would be performed.
+    This function terminates the execution by calling sys.exit upon completion."""
+
+    # This way we only query the pods related with <JOBSET_NAME>
+    label_selector = f"jobset.sigs.k8s.io/jobset-name={JOBSET_NAME_TARGET}"
+    try:
+      # Step 1: Identify the nodes for slice -0
+      pods_pw = KUBE_API.list_namespaced_pod(
+          namespace=NAMESPACE,
+          label_selector=label_selector
+      )
+      target_nodes = set()
+      for pod in pods_pw.items:
+          if "-pwwk-0" in pod.metadata.name and pod.spec.node_name is not None:
+            target_nodes.add(pod.spec.node_name)
+
+      if not target_nodes:
+          print(f"No workers found for JobSet: {JOBSET_NAME_TARGET} (slice -0)", file=sys.stderr)
+          sys.exit(1)
+
+      print(f"Found target nodes to drain: {target_nodes}", file=sys.stderr)
+
+      # Step 2: Process each node
+      for node_name in target_nodes:
+          prefix = "[DRY RUN] Would cordon node" if dry_run else "Cordoning node"
+          print(f"{prefix}: {node_name}", file=sys.stderr)
+          if not dry_run:
+              try:
+                  # Patching spec.unschedulable to True (Cordon)
+                  KUBE_API.patch_node(
+                      name=node_name,
+                      body={"spec": {"unschedulable": True}}
+                  )
+                  print(f"Cordon succeeded for node: {node_name}", file=sys.stderr)
+              except Exception as e:
+                  print(f"Failed to cordon {node_name}: {e}", file=sys.stderr)
+                  continue
+
+          # Step 3: Evict pods
+          try:
+              # List all pods on the node regardless of dry-run status for verbose confirmation
+              node_pods = KUBE_API.list_pod_for_all_namespaces(field_selector=f"spec.nodeName={node_name}")
+              for pod in node_pods.items:
+                  # Skip terminal pods
+                  if pod.status.phase in ["Succeeded", "Failed"]:
+                      continue
+
+                  # Check for DaemonSet owners
+                  is_daemonset = False
+                  if pod.metadata.owner_references:
+                      for owner in pod.metadata.owner_references:
+                          if owner.kind == "DaemonSet":
+                              is_daemonset = True
+                              break
+
+                  is_mirror = "kubernetes.io/config.mirror" in (pod.metadata.annotations or {})
+
+                  if is_daemonset or is_mirror:
+                      continue
+
+                  action_prefix = "[DRY RUN] Would evict" if dry_run else "Evicting"
+                  print(f"{action_prefix} pod: {pod.metadata.namespace}/{pod.metadata.name}", file=sys.stderr)
+
+                  if not dry_run:
+                      eviction = kubernetes.client.V1Eviction(
+                          api_version="policy/v1",
+                          kind="Eviction",
+                          metadata=kubernetes.client.V1ObjectMeta(
+                              name=pod.metadata.name,
+                              namespace=pod.metadata.namespace
+                          )
+                      )
+                      try:
+                          KUBE_API.create_namespaced_pod_eviction(
+                              name=pod.metadata.name,
+                              namespace=pod.metadata.namespace,
+                              body=eviction
+                          )
+                      except Exception as ev_e:
+                          print(f"Eviction failed for {pod.metadata.name} due to {ev_e}. Falling back to forceful delete.", file=sys.stderr)
+                          try:
+                              # Matches author intent established in existing delete_node_pw/delete_pod_pw functions
+                              KUBE_API.delete_namespaced_pod(
+                                  name=pod.metadata.name,
+                                  namespace=pod.metadata.namespace,
+                                  grace_period_seconds=0
+                              )
+                          except Exception as del_e:
+                              print(f"Delete failed for {pod.metadata.name}: {del_e}", file=sys.stderr)
+          except Exception as e:
+              print(f"Failed to list or process pods for {node_name}: {e}", file=sys.stderr)
+
+      print(f"Drain action completed for nodes: {target_nodes}", file=sys.stderr)
+      sys.exit(0)
+
+    except Exception as e:
+        print(f"Exception encountered during drain operation: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+
+
 def delete_pod_pw(dry_run: bool = False):
     """ Delete Pathways head pod
     Args:
@@ -375,6 +480,8 @@ if __name__ == '__main__':
   # restarts again.
   # If DELETE_MODE: node
   # - Trigger the node deletion of the pathways worker node. (For Pathways)
+  # If DELETE_MODE: drain
+  # - Trigger the node drain of the pathways worker node. (For Pathways)
 
   if DELETE_MODE:
     time_elapsed = 0
@@ -400,6 +507,10 @@ if __name__ == '__main__':
         elif DELETE_MODE == "node":
           print(f"Target step {deletion_target_step} reached. Triggering node deletion...", file=sys.stderr)
           delete_node_pw(dry_run=False)
+          sys.exit(0)
+        elif DELETE_MODE == "drain":
+          print(f"Target step {deletion_target_step} reached. Triggering node drain...", file=sys.stderr)
+          drain_nodes_pw(dry_run=True)
           sys.exit(0)
       print(f"[{time_elapsed}/{JOBSET_HEALTHY_TIMEOUT}]: Waiting for target step {deletion_target_step} in logs...", file=sys.stderr)
       time.sleep(60)

--- a/tpu/arc-pw-elastic-startup.sh
+++ b/tpu/arc-pw-elastic-startup.sh
@@ -71,7 +71,7 @@ sed -i "/trn2_config = _generate_trn2_custom_configs/a \    max_step=$MAX_STEPS"
 sed -i "/max_step=max_step,/a \            save_every_n_steps=$STEPS_CHECKPOINT," /root/axlearn/experiments/text/gpt/fuji.py
 
 python3 -m axlearn.common.launch_trainer_main \
- --module=text.gpt.c4_trainer --config=fuji-test-v2 \
+ --module=text.gpt.c4_trainer --config=fuji-7B-v1-flash \
  --trainer_dir=${GCS_PREFIX}/runs/${GIT_BRANCH}/${GH_RUN_ID} \
  --data_dir=gs://axlearn-public/tensorflow_datasets \
  --jax_backend=proxy \

--- a/tpu/arc-pw-elastic-startup.sh
+++ b/tpu/arc-pw-elastic-startup.sh
@@ -18,7 +18,7 @@ echo "About to pull branch $GIT_BRANCH from origin $GIT_ORIGIN"
 
 # Check if Checkpoint Steps were passed. If not 100 default.
 if [ -z "$STEPS_CHECKPOINT" ]; then
-    STEPS_CHECKPOINT=50
+    STEPS_CHECKPOINT=20
 else
     STEPS_CHECKPOINT="$STEPS_CHECKPOINT"
 fi
@@ -71,7 +71,7 @@ sed -i "/trn2_config = _generate_trn2_custom_configs/a \    max_step=$MAX_STEPS"
 sed -i "/max_step=max_step,/a \            save_every_n_steps=$STEPS_CHECKPOINT," /root/axlearn/experiments/text/gpt/fuji.py
 
 python3 -m axlearn.common.launch_trainer_main \
- --module=text.gpt.c4_trainer --config=fuji-7B-v2-flash \
+ --module=text.gpt.c4_trainer --config=fuji-test-v2 \
  --trainer_dir=${GCS_PREFIX}/runs/${GIT_BRANCH}/${GH_RUN_ID} \
  --data_dir=gs://axlearn-public/tensorflow_datasets \
  --jax_backend=proxy \

--- a/tpu/arc-pw-elastic-startup.sh
+++ b/tpu/arc-pw-elastic-startup.sh
@@ -28,6 +28,14 @@ if [ -z "$MAX_STEPS" ]; then
     MAX_STEPS=100
 fi
 
+# If ENABLED_REPLICA_RESIZE enabled use fuji-7B-v1-flash as config model
+# fuji-7B-v1-flash fit into one slice.
+if [ "$ENABLED_REPLICA_RESIZE" == "true" ]; then
+    CONFIG_MODEL="fuji-7B-v1-flash"
+else
+    CONFIG_MODEL="fuji-7B-v2-flash"
+fi
+
 # Grab the latest AXLearn from upstream
 git init /root && cd /root
 git remote add origin $GIT_ORIGIN
@@ -71,7 +79,7 @@ sed -i "/trn2_config = _generate_trn2_custom_configs/a \    max_step=$MAX_STEPS"
 sed -i "/max_step=max_step,/a \            save_every_n_steps=$STEPS_CHECKPOINT," /root/axlearn/experiments/text/gpt/fuji.py
 
 python3 -m axlearn.common.launch_trainer_main \
- --module=text.gpt.c4_trainer --config=fuji-7B-v1-flash \
+ --module=text.gpt.c4_trainer --config=${CONFIG_MODEL} \
  --trainer_dir=${GCS_PREFIX}/runs/${GIT_BRANCH}/${GH_RUN_ID} \
  --data_dir=gs://axlearn-public/tensorflow_datasets \
  --jax_backend=proxy \


### PR DESCRIPTION
### Description of the changes
These changes are mainly related to Pathways Elastic Training tests.

- Rename Pathways Elastic Training tests to `github/workflows/pw-elastic-pause-resume-test.yaml` and `.github/workflows/pw-elastic-replica-resize-test.yaml`.
-   Add `ENABLED_PAUSE_RESUME` and `ENABLED_REPLICA_RESIZE ` as env variables to be controlled from upstream yaml file.
-  Replica Resize and Pause Resume are running with latest proxy_server images jax 0.10.0
- These 2 test point to cienet/elastic_training on Axlearn repository. (Since pathways elastic training has not been merge into official Axlearn repo)
- Added `drain_nodes_pw` function for Replica Resize test. It will drain nodes to interrupt the workload.
-  For Replica resize we used `fuji-v1-flash` model since is the only one that fits on one slice 4x4 v6e topology after the slice goes down.